### PR TITLE
fix argument list too long

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741010256,
-        "narHash": "sha256-WZNlK/KX7Sni0RyqLSqLPbK8k08Kq7H7RijPJbq9KHM=",
+        "lastModified": 1751984180,
+        "narHash": "sha256-LwWRsENAZJKUdD3SpLluwDmdXY9F45ZEgCb0X+xgOL0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ba487dbc9d04e0634c64e3b1f0d25839a0a68246",
+        "rev": "9807714d6944a957c2e036f84b0ff8caf9930bc0",
         "type": "github"
       },
       "original": {
@@ -44,11 +44,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744628928,
-        "narHash": "sha256-BwQ3wAR02CJh7Bp/phXkiSKKqIrPqJFgppQA48ia9ak=",
+        "lastModified": 1752285014,
+        "narHash": "sha256-3vujuhx+cXkQ+nWvLzQVPp/K6p5PQoAbDVoYhkUBC8o=",
         "owner": "snylonue",
         "repo": "packwiz2nix",
-        "rev": "fbe4f497509cf737e2a55231e239900a886616da",
+        "rev": "22056f23288edc15cc8be1d5d70c95ee650f9148",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
nix 通过环境变量传递脚本。我们在 `installPhase` 这一阶段通过脚本拷贝了大量文件，使脚本长度可能超过系统的限制。现改为先将脚本写入文件再执行，改动在 [packwiz2nix](https://github.com/snylonue/packwiz2nix/commit/22056f23288edc15cc8be1d5d70c95ee650f9148) 中