### PR TITLE
限制版本检查Action运行条件

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -10,6 +10,10 @@ permissions:
 
 jobs:
   check-version:
+    if: |
+      github.event_name == 'issues' && 
+      (github.event.action == 'opened' || 
+      (github.event.action == 'edited' && github.event.changes.body))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
限制版本检查Action运行条件为仅在打开issue与编辑issue正文时运行，防止在手动打开issue时action依然将其关闭