### PR TITLE
紧急修复ME网络在多人游戏下FTB UUID不同步，导致没权限

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -1813,7 +1813,7 @@ metafile = true
 
 [[files]]
 file = "mods/gtocore-0.3.7.jar"
-hash = "d1a5e73d9e3d63894f8c4b6a09dc64efd2cdd6faf19d5bcca1cfc5a66e91e4f0"
+hash = "db32dd722510851c861c4402e03a0954583f362357f233e8cf244c369d4a6290"
 
 [[files]]
 file = "mods/guideme.pw.toml"

--- a/index.toml
+++ b/index.toml
@@ -1813,7 +1813,7 @@ metafile = true
 
 [[files]]
 file = "mods/gtocore-0.3.7.jar"
-hash = "db32dd722510851c861c4402e03a0954583f362357f233e8cf244c369d4a6290"
+hash = "44781fb8d582447631603b8556d44599ed2d5c6f299dc277722d87328d5d655e"
 
 [[files]]
 file = "mods/guideme.pw.toml"

--- a/pack.toml
+++ b/pack.toml
@@ -5,7 +5,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "f929216fa080a0d75a5e9613e1e175b40e5516dcf416f29a641b6c8c8610f037"
+hash = "f879a5c680622a8a9e78e3550095a3d00d63ee63cef816579506956b812b3e64"
 
 [versions]
 forge = "47.4.1"

--- a/pack.toml
+++ b/pack.toml
@@ -5,7 +5,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "f879a5c680622a8a9e78e3550095a3d00d63ee63cef816579506956b812b3e64"
+hash = "b68076d3ab2767c24f117557a4fa18bee4dcdc34fc0628ac54def0383dfb206d"
 
 [versions]
 forge = "47.4.1"


### PR DESCRIPTION
ME无线连接器修复：所有使用了无线功能的玩家必须删除  (存档/data/wireless_saved_data.dat) 这个文件。内含错误数据