### PR TITLE
Rename 'Powered' to 'Dust' for consistent naming in game

### DIFF
--- a/config/openloader/resources/resources/assets/enderio/lang/en_us.json
+++ b/config/openloader/resources/resources/assets/enderio/lang/en_us.json
@@ -1,0 +1,12 @@
+{
+    "item.enderio.powdered_coal": "Coal Dust",
+    "item.enderio.powdered_cobalt": "Cobalt Dust",
+    "item.enderio.powdered_copper": "Copper Dust",
+    "item.enderio.powdered_ender_pearl": "Ender Pearl Dust",
+    "item.enderio.powdered_gold": "Gold Dust",
+    "item.enderio.powdered_iron": "Iron Dust",
+    "item.enderio.powdered_obsidian": "Obsidian Dust",
+    "item.enderio.powdered_quartz": "Quartz Dust",
+    "item.enderio.powdered_tin": "Tin Dust",
+    "item.enderio.powdered_lapis_lazuli": "Lapis Lazuli Dust"
+}

--- a/index.toml
+++ b/index.toml
@@ -1381,6 +1381,10 @@ file = "config/openloader/resources/resources/assets/emi/lang/zh_cn.json"
 hash = "b518ca8e321baf941eb799d7d270b209945f60ed1a7b1ae55d3fe91ec16ce22d"
 
 [[files]]
+file = "config/openloader/resources/resources/assets/enderio/lang/en_us.json"
+hash = "f220fa4cb6bf6ea3248fe36b02bd00c7612b44f0e394ee82a082e4a73bfda100"
+
+[[files]]
 file = "config/openloader/resources/resources/assets/factory_blocks/lang/zh_cn.json"
 hash = "b868579684fa2988f8da485d62c42953824489c5765391baad400b061fe430df"
 

--- a/pack.toml
+++ b/pack.toml
@@ -5,7 +5,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "0e7c51be54c7c2f724deaa720b2f7138966915f3407d99b091cb5a75dc8abd43"
+hash = "bc6d9afc27a7998d26e215bd19815d6ce1abea2c8374bfec3390b654617df1e6"
 
 [versions]
 forge = "47.4.1"


### PR DESCRIPTION
Powdered xxx -> xxx Dust

![](https://github.com/user-attachments/assets/3e3e0685-d388-4d52-a159-eae3a3cb701a)

fixes #483
