### PR TITLE
fix: 修复主菜单加载材质包后进世界地形透明

### DIFF
--- a/config/fancymenu/customization/title_screen_layout.txt
+++ b/config/fancymenu/customization/title_screen_layout.txt
@@ -387,8 +387,8 @@ element {
   anchor_point_element = cf619a10-3e39-4548-afdc-296d5d9d76a0-1768309612865
   advanced_posx = {"placeholder":"calc","values":{"expression":"{"placeholder":"guiwidth"}/16*2","decimal":"false"}}
   advanced_posy = {"placeholder":"elementposy","values":{"id":"cf619a10-3e39-4548-afdc-296d5d9d76a0-1768309612865"}}
-  advanced_width = {"placeholder":"elementheight","values":{"id":"cf619a10-3e39-4548-afdc-296d5d9d76a0-1768309612865"}}
-  advanced_height = {"placeholder":"elementheight","values":{"id":"cf619a10-3e39-4548-afdc-296d5d9d76a0-1768309612865"}}
+  advanced_width = {"placeholder":"calc","values":{"expression":"{"placeholder":"guiheight"}/4.5+1","decimal":"false"}}
+  advanced_height = {"placeholder":"calc","values":{"expression":"{"placeholder":"guiheight"}/4.5+1","decimal":"false"}}
   x = -189
   y = 4
   width = 50
@@ -439,8 +439,8 @@ element {
   sticky_anchor = true
   anchor_point = mid-centered
   advanced_posy = {"placeholder":"calc","values":{"expression":"{"placeholder":"guiwidth"} /10","decimal":"false"}}
-  advanced_width = {"placeholder":"calc","values":{"expression":"{"placeholder":"guiheight"} /4.5/355*1024","decimal":"false"}}
-  advanced_height = {"placeholder":"calc","values":{"expression":"{"placeholder":"guiheight"} /4.5","decimal":"false"}}
+  advanced_width = {"placeholder":"calc","values":{"expression":"{"placeholder":"guiheight"}/4.5/355*1024+1","decimal":"false"}}
+  advanced_height = {"placeholder":"calc","values":{"expression":"{"placeholder":"guiheight"}/4.5+1","decimal":"false"}}
   x = 0
   y = -56
   width = 50

--- a/config/fancymenu/customization/title_screen_layout.txt
+++ b/config/fancymenu/customization/title_screen_layout.txt
@@ -1102,9 +1102,9 @@ vanilla_button {
   sticky_anchor = false
   anchor_point = bottom-left
   x = 2
-  y = -21
-  width = 101
-  height = 19
+  y = -70
+  width = 360
+  height = 70
   stretch_x = false
   stretch_y = false
   stay_on_screen = true
@@ -1124,7 +1124,7 @@ vanilla_button {
   advanced_vertical_tilt_mode = false
   horizontal_tilt_degrees = 0.0
   advanced_horizontal_tilt_mode = false
-  is_hidden = false
+  is_hidden = true
   automated_button_clicks = 0
   parallax_intensity_x = 0.5
   parallax_intensity_y = 0.5

--- a/index.toml
+++ b/index.toml
@@ -734,7 +734,7 @@ hash = "d4e6e2f15846c0a6159e0df45bc85966cfbcc043a426c1b52e1ad465f7848c56"
 
 [[files]]
 file = "config/fancymenu/customization/title_screen_layout.txt"
-hash = "03447a42ba552151fde40124dd03985f41f3b82a0812c9fcb1d518595b20afa1"
+hash = "b809e120fe1adc3c989355f8c18cffd70d52170939967f12135f506b5d5f2cdc"
 
 [[files]]
 file = "config/fancymenu/layout_editor/widgets/element_layer_control.lewidget"

--- a/pack.toml
+++ b/pack.toml
@@ -5,7 +5,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "3845956bde2a67245841862935662165d732c9b7f96bf071eeb3216999e30c32"
+hash = "a9559694600c1ec87dcab51f27d028b4e1d14965c835b2b1190f081e70282a2a"
 
 [versions]
 forge = "47.4.20"


### PR DESCRIPTION
## 问题

1. 在主菜单启用/切换任意材质包后进入世界，地形会变成透明（透视）。去掉 FancyMenu 后问题消失。
2. 主菜单左下角 branding 信息过多（MC / Forge / MCP / ModernFix 版本等），希望不显示。

## 原因（地形透明）

`title_screen_layout.txt` 中主界面 Logo 按钮使用标题图元素的 `elementheight` 计算宽高。主菜单资源重载后，标题高度可能暂时为 **0**，FancyMenu 在 `ExtendedButton.renderBackground` 中除零，污染 OpenGL 状态，导致 Embeddium 渲染世界时地形透明。

## 修改

### 1. 修复材质包重载后地形透明
文件：`config/fancymenu/customization/title_screen_layout.txt`

- Logo 宽高：由 `elementheight` 改为 `guiheight/4.5+1`（始终 ≥ 1）
- 标题图宽高：原有公式上 `+1`，避免重载瞬间为 0

### 2. 隐藏主菜单左下角 branding
同一布局文件中将 `minecraft_branding_widget` 设为 `is_hidden = true`，不再显示版本与相关文字。

## 验证

1. 主菜单加载任意材质包后进世界，地形正常
2. 主菜单左下角无 MC/Forge/MCP/ModernFix 等 branding 文字
3. Logo / 标题外观正常

## 说明

地形问题是 FancyMenu 布局在资源重载边界下的配置缺陷，不是某个材质包内容损坏。